### PR TITLE
Add import_vitek_ast and import_whonet_ast functions

### DIFF
--- a/R/import_pheno.R
+++ b/R/import_pheno.R
@@ -252,8 +252,11 @@ import_ebi_ast <- function(input, sample_col = "phenotype-BioSample_ID", source 
     cat("Warning: Expected AST platform column 'phenotype-platform' not found in input\n")
   }
 
-  # Note: EBI web format doesn't have a separate method column, so we leave method unset
-  # Users can infer method from mic/disk columns
+  if ("phenotype-laboratory_typing_method" %in% colnames(ast)) {
+    ast <- ast %>% mutate(method = `phenotype-laboratory_typing_method`)
+  } else {
+    cat("Warning: Expected AST method column 'phenotype-laboratory_typing_method' not found in input\n")
+  }
 
   if ("phenotype-ast_standard" %in% colnames(ast)) {
     ast <- ast %>% mutate(guideline = `phenotype-ast_standard`)

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,6 +110,7 @@ utils::globalVariables(c(
   "pheno_mic",
   "pheno_MIC",
   "phenotype-AMR_associated_publications",
+  "phenotype-laboratory_typing_method",
   "platform",
   "phenotype-antibiotic_name",
   "phenotype-ast_standard",


### PR DESCRIPTION
## Summary
- Adds new `import_vitek_ast()` function to import wide-format Vitek AST output files and convert them to the standardised long-format used by AMRgen
- Adds new `import_whonet_ast()` function to import wide-format WHONET software output files and convert them to the standardised long-format used by AMRgen
- Updates `import_ast()` wrapper to support `format="vitek"` and `format="whonet"`
- Standardises column semantics across all import functions with new `method` and `platform` columns
- Adds global variable declarations in `utils.R` to avoid R CMD check notes

## Column Standardisation
All import functions now consistently use:
- **`method`**: AST methodology (MIC, disk diffusion, Etest, agar dilution)
- **`platform`**: instrument/system (Vitek, Phoenix, Microscan, Sensititre)
- **`guideline`**: testing standard (CLSI, EUCAST, DIN)

## Vitek Features
- Parses antibiotic triplets: `{CODE}-{Name}`, `{CODE}-Other-Instrument`, `{CODE}-Other-Expertized`
- Supports expertised vs instrument SIR selection via `use_expertized` parameter
- Prioritises full drug name over code for antibiotic mapping (more reliable)
- Handles MIC values including special cases (empty, "-", "NEG")
- Optional `instrument_guideline` parameter to record the guideline used by the instrument
- Optional date column inclusion
- Source column only added when explicitly specified
- Sets `method="MIC"` and `platform="Vitek"`

## WHONET Features
- Parses antibiotic columns with `{CODE}_{GUIDELINE/PLATFORM}{METHOD}{POTENCY}` pattern
- Method code parsing based on official WHONET documentation:
  - **Standard codes**: N=CLSI, E=EUCAST, D=DIN (guideline); D=Disk, M=MIC, E=Etest (method)
  - **Platform codes**: V=Vitek, P=Phoenix, M=Microscan, S=Sensititre, K=Trek
  - e.g., `ND10` → guideline=CLSI, method=disk diffusion, disk_potency=10
  - e.g., `VM` → platform=Vitek, method=MIC
  - Reference: https://whonet.org/WebDocs/WHONET%202.Laboratory%20configuration.html
- Populates `method`, `platform`, `guideline`, and `disk_potency` columns
- Extracts S/I/R interpretations from wide format
- Parses organism codes to species
- Optional patient demographic info inclusion
- Source column only added when explicitly specified

## Other Updated Functions
- `import_ncbi_ast()`: Now uses `platform` from 'Laboratory typing platform', `method` from 'Laboratory typing method'
- `import_ebi_ast()`: Now uses `platform` from 'phenotype-platform'
- `import_ebi_ast_ftp()`: Now uses `platform` from 'platform', `method` from 'laboratory_typing_method'

## Test plan
- [x] Test Vitek import with CSV output file
- [x] Test WHONET import with CSV output file
- [x] Verify wide-to-long pivot produces correct row counts
- [x] Verify antibiotic and SIR parsing
- [x] Verify WHONET method/platform/guideline parsing against official documentation
- [x] Test `import_ast()` wrapper with both formats
- [x] Verify method/platform separation works correctly