### PR TITLE
updating import_kleborate() function

### DIFF
--- a/R/import_kleborate.R
+++ b/R/import_kleborate.R
@@ -69,7 +69,8 @@ import_kleborate <- function(input_table,
         paste0(gene, ":-"),
         marker
       )) %>%
-      relocate(Kleborate_Class, .after = "variation type")
+      relocate(Kleborate_Class, .after = "variation type") %>%
+      mutate(drug_agent=NA)
   } else { # older versions use informal nomenclature (e.g. [gene]-[mutation], [gene]-X%, OmpK36GD)
     geno_table <- geno_table %>%
       mutate(`variation type` = case_when(
@@ -79,12 +80,15 @@ import_kleborate <- function(input_table,
         grepl("_mut", Kleborate_Class) & marker %in% c("OmpK36GD", "OmpK36TD") ~ "Protein variant detected",
         TRUE ~ "Gene presence detected"
       )) %>%
-      separate(marker, into = c("gene", "mutation"), sep = ":", remove = FALSE, fill = "right") %>%
+      mutate(gene = if_else(grepl("%", marker), sub("-.*", "", marker), marker),
+             mutation = if_else(grepl("%", marker), sub(".*-", "", marker),NA
+            )) %>%
       mutate(marker.label = if_else(`variation type` == "Inactivating mutation detected",
-        paste0(gene, ":-"),
-        marker
-      )) %>%
-      relocate(Kleborate_Class, .after = "variation type")
+          paste0(gene, ":-"),
+          marker
+      ))%>%
+      relocate(Kleborate_Class, .after = "variation type") %>%
+      mutate(drug_agent=NA)
   }
 
   return(geno_table)


### PR DESCRIPTION
1. Updating the import_kleborate() function for `hgvs=FALSE` option (importing Kleborate <=v3.1.3 output)

For the [gene]-X% notation,
- previously the function split the gene and truncation based on `:`
- it has now been changed to split the gene and truncation based on `-` 
- `:-` is added to the end of the marker (`[gene]:-`) to indicate an 'Inactivating mutation detected' (e.g., OmpK36:-, MgrB:-) 

2. Adding a `drug_agent` column where all row values are `NA` since Kleborate operates at a drug_class level. The `drug_agent` column is necessary for some downstream AMRgen functions like get_binary_matrix().