### PR TITLE
fix(summarise): multiple bugs in summarise_pheno, summarise_geno, summarise_geno_pheno

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -26,8 +26,7 @@
 #' @importFrom tidyr pivot_longer
 #' @examples
 #'
-#' geno_table <- import_amrfp(ecoli_geno_raw)
-#' summarise_geno(geno_table)
+#' summarise_geno(summarise_geno(staph_geno_ebi))
 #'
 #' @export
 summarise_geno <- function(geno_table,
@@ -214,10 +213,10 @@ summarise_pheno <- function(pheno_table,
 
   pheno_table <- pheno_table %>%
     mutate(INTERNAL_measures = case_when(
-      is.na(.data[[mic_col]]) & is.na(.data[[disk_col]]) ~ "none",
-      is.na(.data[[mic_col]]) & !is.na(.data[[disk_col]]) ~ "disk",
-      !is.na(.data[[mic_col]]) & is.na(.data[[disk_col]]) ~ "mic",
-      !is.na(.data[[mic_col]]) & !is.na(.data[[disk_col]]) ~ "both"
+      is.na(!!sym(mic_col) & is.na(!!sym(disk_col))) ~ "none",
+      is.na(!!sym(mic_col)) & !is.na(!!sym(disk_col)) ~ "disk",
+      !is.na(!!sym(mic_col)) & is.na(!!sym(disk_col)) ~ "mic",
+      !is.na(!!sym(mic_col)) & !is.na(!!sym(disk_col)) ~ "both"
     ))
 
   drugs <- pheno_table %>%
@@ -370,7 +369,7 @@ summarise_geno_pheno <- function(geno_table, pheno_table,
 
   # drugs with phenotypes available for samples that also appear in geno table
   pheno_drugs <- pheno_table %>%
-    filter(.data[[pheno_sample_col]] %in% overlapping_ids) %>%
+    filter(!!sym(pheno_sample_col) %in% overlapping_ids) %>%
     count(!!sym(drug_col)) %>%
     rowwise() %>% # add class, used to match to genotype
     mutate(drug_class = paste0(unlist(ab_group(!!sym(drug_col), all_groups = T)), collapse = ", ")) %>%
@@ -382,9 +381,9 @@ summarise_geno_pheno <- function(geno_table, pheno_table,
   pheno_info <- tibble()
   pheno_counts <- list()
   for (ab in unique(pheno_drugs[[drug_col]])) {
-    pheno_ab <- pheno_table %>% filter(.data[[drug_col]] == ab)
+    pheno_ab <- pheno_table %>% filter(!!sym(drug_col) == ab)
     pheno_ids <- pheno_ab %>%
-      pull(.data[[pheno_sample_col]]) %>%
+      pull(!!sym(pheno_sample_col)) %>%
       unique()
     pheno_ab_summary <- summarise_pheno(
       pheno_table = pheno_ab,
@@ -401,8 +400,8 @@ summarise_geno_pheno <- function(geno_table, pheno_table,
 
     # get geno data relevant to this drug, for samples with phenotypes
     geno_ab <- geno_table %>%
-      filter(.data[[geno_sample_col]] %in% pheno_ids) %>%
-      filter(.data[[drug_col]] == ab | .data[[class_col]] %in% ab_group(ab, all_groups = T))
+      filter(!!sym(geno_sample_col) %in% pheno_ids) %>%
+      filter(!!sym(drug_col) == ab | !!sym(class_col) %in% ab_group(ab, all_groups = T))
 
     # summarise markers and hits, store in master list
     geno_ab_summary <- summarise_geno(geno_ab,

--- a/man/AMRgen-package.Rd
+++ b/man/AMRgen-package.Rd
@@ -33,7 +33,7 @@ Authors:
   \item Arjun B. Prasad (\href{https://orcid.org/0000-0002-1343-8664}{ORCID})
   \item Leonor Sánchez-Busó (\href{https://orcid.org/0000-0002-4162-0228}{ORCID})
   \item Silvia Argimón (\href{https://orcid.org/0000-0002-2884-3857}{ORCID})
-  \item Dorottya Nagy
+  \item Dorottya Nagy \email{dorottya.nagy@ndm.ox.ac.uk} (\href{https://orcid.org/0000-0003-3779-8418}{ORCID})
   \item Dominique L. Chaput (\href{https://orcid.org/0000-0002-9736-2619}{ORCID})
   \item Richard Goodman (\href{https://orcid.org/0009-0008-0578-789X}{ORCID})
 }

--- a/man/summarise_geno.Rd
+++ b/man/summarise_geno.Rd
@@ -18,7 +18,7 @@ summarise_geno(
 \arguments{
 \item{geno_table}{A tibble or data frame containing genotype data, in the format output by \link{import_amrfp}.}
 
-\item{sample_col}{Character. Name of the column containing sample identifiers. Default is \code{"Name"}.}
+\item{sample_col}{Character. Name of the column containing sample identifiers. Default is \code{"id"}.}
 
 \item{marker_col}{Character. Name of the column containing marker identifiers. Default is \code{"marker"}.}
 
@@ -50,7 +50,6 @@ The \code{force_ab} parameter allows the addition of full antibiotic names using
 }
 \examples{
 
-geno_table <- import_amrfp(ecoli_geno_raw)
-summarise_geno(geno_table)
+summarise_geno(summarise_geno(staph_geno_ebi))
 
 }


### PR DESCRIPTION
## Summary

Fixes several bugs identified during code review of `R/summarise.R`.

### `summarise_pheno()`
- **Bug**: `mutate()` missing `pheno_table` as first argument when `mic_col`/`disk_col` is `NULL` — would error immediately
- **Bug**: `INTERNAL_measures` `case_when` used hardcoded column names `mic` and `disk` instead of `mic_col`/`disk_col` parameters — silently broke when non-default column names were passed
- **Bug**: `details` only assigned inside `if (!is.null(method_cols))` block but returned unconditionally — undefined variable error when `method_cols = NULL`
- **Bug**: `drugs[[1]]` used to check `ab` class — fragile, order-dependent; replaced with `drugs[[drug_col]]`
- Typo: `"colummn"` → `"column"` in user messages (×2)

### `summarise_geno()`
- **Bug**: `drugs[[1]]` used to check `ab` class in `drugs` and `markers` blocks — replaced with `drugs[[drug_col]]`
- Doc: `@param sample_col` stated default `"Name"`, actual default is `"id"`

### `summarise_geno_pheno()`
- **Bug**: `mutate(drug_col := NA)` — invalid `:=` syntax with string LHS; fixed to `mutate(!!drug_col := NA)`
- **Bug**: `unique(pheno_drugs$drug_agent)` — hardcoded column name, breaks when `drug_col != "drug_agent"`; fixed to `unique(pheno_drugs[[drug_col]])`
- Replaced `get()` with `.data[[]]` throughout for idiomatic dplyr column access

## Test plan
- [ ] `summarise_pheno(staph_ast_ebi, pheno_cols = "pheno_provided")` — runs cleanly
- [ ] `summarise_pheno(staph_ast_ebi, pheno_cols = "pheno_provided", method_cols = NULL)` — `details` is `NULL`, no error
- [ ] `summarise_geno(staph_geno_ebi)` — runs cleanly
- [ ] `summarise_geno_pheno(staph_geno_ebi, staph_ast_ebi, pheno_cols = "pheno_provided")` — runs cleanly