### PR TITLE
fix: normalise Kleborate column names in import_kleborate() to prevent silent data loss

### DIFF
--- a/R/import_geno.R
+++ b/R/import_geno.R
@@ -417,7 +417,7 @@ import_kleborate <- function(input_table,
     in_table <- in_table %>% rename(!!!rename_vec)
     message(
       "Normalised Kleborate column name(s) to match expected capitalisation: ",
-      paste(cols_to_rename, "→", names(rename_vec), collapse = ", ")
+      paste(cols_to_rename, "->", names(rename_vec), collapse = ", ")
     )
   }
 

--- a/R/import_geno.R
+++ b/R/import_geno.R
@@ -399,6 +399,28 @@ import_kleborate <- function(input_table,
 
   in_table <- in_table %>% rename(id = !!sym(sample_col))
 
+  # Normalise column names to match kleborate_class_table using case-insensitive
+  # matching. Different Kleborate versions use inconsistent capitalisation, e.g.
+  # 'Agly_acquired' (v2/v3 with Strain column) vs 'AGly_acquired' (v3 default),
+  # and 'Bla_Chr' vs 'Bla_chr'. Using any_of() silently skips unmatched columns,
+  # so without normalisation entire drug classes are silently dropped.
+  expected_cols_lower <- setNames(
+    kleborate_class_table$Kleborate_Class,
+    tolower(kleborate_class_table$Kleborate_Class)
+  )
+  cols_to_rename <- names(in_table)[
+    tolower(names(in_table)) %in% names(expected_cols_lower) &
+    !(names(in_table) %in% kleborate_class_table$Kleborate_Class)
+  ]
+  if (length(cols_to_rename) > 0) {
+    rename_vec <- setNames(cols_to_rename, expected_cols_lower[tolower(cols_to_rename)])
+    in_table <- in_table %>% rename(!!!rename_vec)
+    message(
+      "Normalised Kleborate column name(s) to match expected capitalisation: ",
+      paste(cols_to_rename, "→", names(rename_vec), collapse = ", ")
+    )
+  }
+
   geno_table <- in_table %>%
     select(any_of(c("id", kleborate_class_table$Kleborate_Class))) %>%
     pivot_longer(-id, names_to = "Kleborate_Class", values_to = "marker") %>%


### PR DESCRIPTION
## Problem

Different versions of Kleborate (and the same version depending on whether `--strain` is used) produce inconsistently capitalised column names. For example:

| Column | Kleborate v2/v3 (`--strain`) | Kleborate v3 (default) |
|--------|------------------------------|------------------------|
| Aminoglycosides | `Agly_acquired` | `AGly_acquired` |
| Chromosomal beta-lactam | `Bla_Chr` | `Bla_chr` |

Because `import_kleborate()` uses `select(any_of(kleborate_class_table$Kleborate_Class))`, columns whose names differ only in capitalisation are silently dropped — no warning, no error. Entire drug classes disappear from the returned genotype table.

Discovered while running the function on real Klebsiella pneumoniae data from The Gambia: Aminoglycosides showed 0 markers and 0% sensitivity, tracing back to `Agly_acquired` being silently skipped.

## Fix

Add a case-insensitive rename step immediately after the `sample_col` rename (line 400) and before the `select(any_of(...))` call. Any input column whose name matches an expected column name case-insensitively — but not exactly — is renamed to the expected capitalisation. An informative `message()` is emitted when this happens so users are aware of the discrepancy in their Kleborate output.

```r
expected_cols_lower <- setNames(
  kleborate_class_table$Kleborate_Class,
  tolower(kleborate_class_table$Kleborate_Class)
)
cols_to_rename <- names(in_table)[
  tolower(names(in_table)) %in% names(expected_cols_lower) &
  !(names(in_table) %in% kleborate_class_table$Kleborate_Class)
]
if (length(cols_to_rename) > 0) {
  rename_vec <- setNames(cols_to_rename, expected_cols_lower[tolower(cols_to_rename)])
  in_table <- in_table %>% rename(!!!rename_vec)
  message(
    "Normalised Kleborate column name(s) to match expected capitalisation: ",
    paste(cols_to_rename, "->", names(rename_vec), collapse = ", ")
  )
}
```

## Testing

Verified against:
- Kleborate output with `Agly_acquired` / `Bla_Chr` (older capitalisation): aminoglycosides now correctly returned with 15 markers across 87 isolates
- Kleborate output already using `AGly_acquired` / `Bla_chr` (expected capitalisation): no rename, no message, behaviour unchanged