### PR TITLE
added gsub to remove <NA values which cause glue errors

### DIFF
--- a/R/import_pheno.R
+++ b/R/import_pheno.R
@@ -455,7 +455,6 @@ interpret_pheno <- function(ast, interpret_ecoff = TRUE, interpret_eucast = TRUE
 import_ncbi_pheno <- function(input, sample_col = "BioSample", source = NULL, species = NULL, ab = NULL,
                               interpret_eucast = FALSE, interpret_clsi = FALSE, interpret_ecoff = FALSE) {
   ast <- process_input(input)
-
   # find id column
   if (!is.null(sample_col)) {
     if (sample_col %in% colnames(ast)) {
@@ -534,7 +533,8 @@ import_ncbi_pheno <- function(input, sample_col = "BioSample", source = NULL, sp
     if ("Measurement sign" %in% colnames(ast)) {
       ast <- ast %>%
         mutate(mic = paste0(`Measurement sign`, `MIC (mg/L)`)) %>%
-        mutate(mic = gsub("==", "", mic))
+        mutate(mic = gsub("==", "", mic)) %>%
+        mutate(mic = gsub("<NA", "NA", mic))
     } else {
       ast <- ast %>% mutate(mic = `MIC (mg/L)`)
       warning("Expected column 'Measurement sign' not found in input, be careful interpreting MIC")


### PR DESCRIPTION
I recently downloaded all AST data from the NCBI browser.

When I tried to import using this command
```
import_pheno("data/NCBI_asts_15-07-2026.tsv.gz", format="ncbi")
```

I got this error:
```
Error in `mutate()`:
ℹ In argument: `mic = as.mic(mic)`.
Caused by error in `glue()`:
! Expecting 'FCkNXbE-413>'
```

This was occurring here at the final step in this chunk:
https://github.com/AMRverse/AMRgen/blob/bbeac153c9bbc8db406b11f818a409bbc6179af4/R/import_pheno.R#L533-L542

Because the function concatenates the measurement sign with the MIC, it was in some instances creating values that looked like `<NA`. This causes the weird error being thrown by `glue()`, which creates the warning message telling users what mic values couldn't be converted. 

Have added an extra `gsub` command that turns "<NA" into simply "NA", so that the import can complete.